### PR TITLE
fix(common): add pyproject.toml so package is pip-installable

### DIFF
--- a/packages/common/pyproject.toml
+++ b/packages/common/pyproject.toml
@@ -1,0 +1,23 @@
+[build-system]
+requires = ["setuptools>=42"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "civicproof-common"
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = [
+    "pydantic>=2.6.0",
+    "pydantic-settings>=2.2.0",
+    "sqlalchemy>=2.0.28",
+    "asyncpg>=0.29.0",
+    "alembic>=1.13.1",
+    "redis>=5.0.3",
+    "boto3>=1.34.0",
+    "opentelemetry-api>=1.23.0",
+    "opentelemetry-sdk>=1.23.0",
+    "opentelemetry-exporter-otlp-proto-grpc>=1.23.0",
+]
+
+[tool.setuptools.packages.find]
+where = ["src"]


### PR DESCRIPTION
## Problem
`packages/common` had no `pyproject.toml` or `setup.py`, so `pip install -e packages/common` failed:
```
ERROR: File "setup.py" or "setup.cfg" not found. Directory cannot be installed in editable mode
```
All three services reference `civicproof-common @ file://../packages/common` in their `requirements.txt`, making local dev setup broken out of the box.

## Fix
Added `packages/common/pyproject.toml` with `setuptools` build backend and the package's declared dependencies. Mirrors the existing `requirements.txt`.

## Test plan
- [ ] `pip install -e packages/common` succeeds
- [ ] `import civicproof_common` resolves correctly
- [ ] `pip install -r services/api/requirements.txt` resolves `civicproof-common` from the local path

Closes #22