### PR TITLE
fix(common): lazy-evaluate alembic configparser fallback in env.py

### DIFF
--- a/packages/common/src/civicproof_common/db/migrations/env.py
+++ b/packages/common/src/civicproof_common/db/migrations/env.py
@@ -20,7 +20,7 @@ target_metadata = Base.metadata
 
 
 def _get_url() -> str:
-    raw = os.environ.get("DATABASE_URL", config.get_main_option("sqlalchemy.url", ""))
+    raw = os.environ.get("DATABASE_URL") or config.get_main_option("sqlalchemy.url", "")
     if raw.startswith("postgresql://"):
         raw = raw.replace("postgresql://", "postgresql+asyncpg://", 1)
     elif raw.startswith("postgres://"):


### PR DESCRIPTION
## Problem
`env.py:23` used:
```python
raw = os.environ.get("DATABASE_URL", config.get_main_option("sqlalchemy.url", ""))
```
Python evaluates **all arguments eagerly**. Even when `DATABASE_URL` is set, `config.get_main_option` runs and tries to interpolate `%(DATABASE_URL)s` via configparser, raising:
```
InterpolationMissingOptionError: 'database_url' is not a valid option name
```
Migrations fail completely even with a valid `DATABASE_URL` env var.

## Fix
```python
# before
raw = os.environ.get("DATABASE_URL", config.get_main_option("sqlalchemy.url", ""))
# after
raw = os.environ.get("DATABASE_URL") or config.get_main_option("sqlalchemy.url", "")
```
`or` short-circuits — `config.get_main_option` is only called when `DATABASE_URL` is absent.

## Test plan
- [ ] `DATABASE_URL=postgresql+asyncpg://... alembic upgrade head` runs without InterpolationMissingOptionError
- [ ] Migrations complete successfully against local postgres

Closes #24