### PR TITLE
fix(eval): add pyproject.toml so package is pip-installable

### DIFF
--- a/packages/eval/pyproject.toml
+++ b/packages/eval/pyproject.toml
@@ -1,0 +1,14 @@
+[build-system]
+requires = ["setuptools>=42"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "civicproof-eval"
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = [
+    "pydantic>=2.6.0",
+]
+
+[tool.setuptools.packages.find]
+where = ["src"]


### PR DESCRIPTION
## Problem
`packages/eval` had no `pyproject.toml` or `setup.py`, so `pip install -e packages/eval` failed:
```
ERROR: File "setup.py" or "setup.cfg" not found. Directory cannot be installed in editable mode
```

## Fix
Added `packages/eval/pyproject.toml` with `setuptools` build backend. The `civicproof-common` local dependency is not listed in `[project.dependencies]` because `file://` relative paths are unsupported in pyproject.toml — it must be installed separately (which it is, via its own `pyproject.toml`).

## Test plan
- [ ] `pip install -e packages/eval` succeeds
- [ ] `import civicproof_eval` resolves correctly

Closes #23