### PR TITLE
fix(common): guard MINIO keys before passing to S3ObjectStore

### DIFF
--- a/packages/common/src/civicproof_common/storage/object_store.py
+++ b/packages/common/src/civicproof_common/storage/object_store.py
@@ -75,6 +75,8 @@ class S3ObjectStore(ObjectStore):
 
 def build_object_store() -> S3ObjectStore:
     settings = get_settings()
+    if not settings.MINIO_ACCESS_KEY or not settings.MINIO_SECRET_KEY:
+        raise RuntimeError("MINIO_ACCESS_KEY and MINIO_SECRET_KEY must be set")
     endpoint = None
     if settings.MINIO_ENDPOINT:
         scheme = "https" if settings.MINIO_USE_SSL else "http"


### PR DESCRIPTION
## Problem
After the security hardening in fix/security-config, `MINIO_ACCESS_KEY` and `MINIO_SECRET_KEY` became `str | None`. Mypy caught that `build_object_store()` was passing these directly to `S3ObjectStore` which expects `str`:

```
object_store.py:84: error: Argument "access_key" to "S3ObjectStore" has incompatible type "str | None"; expected "str"
object_store.py:85: error: Argument "secret_key" to "S3ObjectStore" has incompatible type "str | None"; expected "str"
```

## Fix
Added an explicit guard before construction. This narrows the type to `str` for mypy and gives a clear `RuntimeError` at startup if the keys are not configured.

## Test plan
- [ ] `mypy packages/common/src --ignore-missing-imports` → no errors
- [ ] CI Mypy check passes