### PR TITLE
fix(mypy): resolve all type errors across worker and api services

### DIFF
--- a/services/api/src/routes/metrics.py
+++ b/services/api/src/routes/metrics.py
@@ -102,7 +102,7 @@ async def get_public_metrics(
     artifacts_24h_result = await db.execute(
         select(func.count())
         .select_from(RawArtifactModel)
-        .where(RawArtifactModel.fetched_at >= day_ago)
+        .where(RawArtifactModel.retrieved_at >= day_ago)
     )
     artifacts_24h = artifacts_24h_result.scalar() or 0
 

--- a/services/worker/src/agents/case_composer.py
+++ b/services/worker/src/agents/case_composer.py
@@ -238,7 +238,7 @@ class CaseComposerAgent:
         self, case_id: str, awards_data: list[dict[str, Any]], artifact_ids: list[str]
     ) -> list[ComposedClaim]:
         """Create factual claims from award data."""
-        claims = []
+        claims: list[ComposedClaim] = []
 
         if not awards_data:
             return claims

--- a/services/worker/src/agents/evidence_retrieval.py
+++ b/services/worker/src/agents/evidence_retrieval.py
@@ -98,7 +98,7 @@ class EvidenceRetrievalAgent:
                 art.retrieved_at
                 and (
                     manifest.freshness[source] is None
-                    or art.retrieved_at > manifest.freshness[source]
+                    or art.retrieved_at > manifest.freshness[source]  # type: ignore[operator]
                 )
             ):
                 manifest.freshness[source] = art.retrieved_at
@@ -108,8 +108,8 @@ class EvidenceRetrievalAgent:
         for source in EXPECTED_SOURCES:
             if source not in manifest.artifacts_by_source:
                 manifest.missing_sources.append(source)
-            elif manifest.freshness.get(source):
-                age = now - manifest.freshness[source]
+            elif manifest.freshness.get(source) is not None:
+                age = now - manifest.freshness[source]  # type: ignore[operator]
                 if age > self._staleness:
                     manifest.stale_sources.append(source)
 

--- a/services/worker/src/agents/graph_builder.py
+++ b/services/worker/src/agents/graph_builder.py
@@ -138,7 +138,10 @@ class GraphBuilderAgent:
             for m2 in resolved[i + 1 :]:
                 if m1.resolved_entity_id == m2.resolved_entity_id:
                     continue
-                pair_key = tuple(sorted([m1.resolved_entity_id, m2.resolved_entity_id]))
+                pair_key = tuple(sorted([
+                    m1.resolved_entity_id or "",
+                    m2.resolved_entity_id or "",
+                ]))
                 if pair_key not in seen:
                     seen.add(pair_key)
                     context = f"{m1.raw_text} <-> {m2.raw_text}"

--- a/services/worker/src/handlers/ingest.py
+++ b/services/worker/src/handlers/ingest.py
@@ -105,7 +105,7 @@ async def handle_artifact_ingested(
         },
         idempotency_key=f"parse:{artifact_id}",
     )
-    await redis_client.rpush(WORKER_QUEUE_KEY, parse_event.model_dump_json())
+    await redis_client.rpush(WORKER_QUEUE_KEY, parse_event.model_dump_json())  # type: ignore[misc]
 
     logger.info(
         "artifact_stored",

--- a/services/worker/src/handlers/parse.py
+++ b/services/worker/src/handlers/parse.py
@@ -32,7 +32,7 @@ def _extract_text(raw_bytes: bytes, doc_type: str) -> tuple[str, dict]:
         try:
             data = json.loads(decoded)
             structured = data if isinstance(data, dict) else {"items": data}
-            text_parts = []
+            text_parts: list[str] = []
             _flatten_json_to_text(data, text_parts)
             text = " ".join(text_parts)
         except json.JSONDecodeError:
@@ -123,7 +123,7 @@ async def handle_parse_requested(
         },
         idempotency_key=f"normalize:{artifact_id}",
     )
-    await redis_client.rpush(WORKER_QUEUE_KEY, normalize_event.model_dump_json())
+    await redis_client.rpush(WORKER_QUEUE_KEY, normalize_event.model_dump_json())  # type: ignore[misc]
 
     logger.info(
         "artifact_parsed",

--- a/services/worker/src/main.py
+++ b/services/worker/src/main.py
@@ -36,7 +36,7 @@ async def _process_message(redis_client: aioredis.Redis, raw: str) -> None:
         envelope = EventEnvelope.model_validate_json(raw)
     except Exception as exc:
         _stdlib_logger.error("failed to parse event envelope: %s | raw=%s", exc, raw[:200])
-        await redis_client.lpush(DEAD_LETTER_KEY, raw)
+        await redis_client.lpush(DEAD_LETTER_KEY, raw)  # type: ignore[misc]
         return
 
     handler = _HANDLERS.get(envelope.event_type)
@@ -73,9 +73,9 @@ async def _process_message(redis_client: aioredis.Redis, raw: str) -> None:
                 payload=retry_payload,
                 idempotency_key=f"{envelope.idempotency_key}:retry:{retry_count}",
             )
-            await redis_client.rpush(QUEUE_KEY, retry_envelope.model_dump_json())
+            await redis_client.rpush(QUEUE_KEY, retry_envelope.model_dump_json())  # type: ignore[misc]
         else:
-            await redis_client.lpush(DEAD_LETTER_KEY, raw)
+            await redis_client.lpush(DEAD_LETTER_KEY, raw)  # type: ignore[misc]
 
 
 class _HealthHandler(http.server.BaseHTTPRequestHandler):
@@ -125,7 +125,7 @@ async def run_worker() -> None:
 
     try:
         while not stop_event.is_set():
-            result = await redis_client.blpop(QUEUE_KEY, timeout=POLL_TIMEOUT)
+            result = await redis_client.blpop([QUEUE_KEY], timeout=POLL_TIMEOUT)  # type: ignore[misc]
             if result is None:
                 continue
             _, raw = result

--- a/services/worker/src/parsers/doj.py
+++ b/services/worker/src/parsers/doj.py
@@ -124,7 +124,7 @@ def _extract_amounts(text: str) -> list[dict[str, Any]]:
     # Deduplicate and sort by value descending
     seen = set()
     unique_amounts = []
-    for a in sorted(amounts, key=lambda x: x["value_usd"], reverse=True):
+    for a in sorted(amounts, key=lambda x: float(x["value_usd"]), reverse=True):  # type: ignore[arg-type]
         if a["value_usd"] not in seen:
             seen.add(a["value_usd"])
             unique_amounts.append(a)


### PR DESCRIPTION
## Problem
CI mypy check was failing across `services/worker` and `services/api` with 10 type errors.

## Fixes

**services/worker/src/parsers/doj.py**
- Cast `value_usd` to `float` before `sorted()` — `object` is not `SupportsDunderLT`

**services/worker/src/agents/evidence_retrieval.py**
- Guard `datetime > None` comparison with `# type: ignore[operator]` (runtime is safe due to `is None` check above)

**services/worker/src/agents/case_composer.py**
- Annotate `claims` with explicit `list[ComposedClaim]` type

**services/worker/src/agents/graph_builder.py**
- Fall back to `""` for `None` `resolved_entity_id` before `sorted()` to satisfy `SupportsRichComparison`

**services/worker/src/handlers/parse.py, ingest.py, main.py**
- Suppress redis stub false positives (`rpush`/`lpush`/`blpop` stubs declare `Awaitable[int] | int` but are always awaitable in asyncio context)
- Pass `blpop` a `list[str]` as required by type stubs

**services/api/src/routes/metrics.py**
- Fix wrong column name `fetched_at` → `retrieved_at` (`RawArtifactModel` only defines `retrieved_at`; this would raise `AttributeError` at runtime)

## Test plan
- [ ] `mypy packages/*/src services/*/src --ignore-missing-imports` → all pass
- [ ] CI Mypy check passes green