### PR TITLE
fix(ci): set PYTHONPATH and install packages for unit test collection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,13 +77,15 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install pytest pytest-cov pytest-asyncio hypothesis
-          for req in packages/*/requirements.txt services/*/requirements.txt; do
+          pip install -e packages/common -e packages/eval
+          for req in services/*/requirements.txt; do
             [ -f "$req" ] && pip install -r "$req"
           done
       - name: Run unit tests
         env:
           DATABASE_URL: postgresql://civicproof:testpass@localhost:5432/civicproof_test
           REDIS_URL: redis://localhost:6379/0
+          PYTHONPATH: packages/common/src:packages/eval/src:services/worker/src:services/api/src:services/gateway/src
         run: |
           if [ -d tests/unit ] && [ -n "$(find tests/unit -name 'test_*.py' 2>/dev/null)" ]; then
             pytest tests/unit/ -v --cov=packages --cov=services --cov-report=xml --cov-fail-under=80
@@ -157,7 +159,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install pytest pytest-cov pytest-asyncio
-          for req in packages/*/requirements.txt services/*/requirements.txt; do
+          pip install -e packages/common -e packages/eval
+          for req in services/*/requirements.txt; do
             [ -f "$req" ] && pip install -r "$req"
           done
       - name: Run eval suite tests

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_root = Path(__file__).parent
+
+# Allow bare imports used in tests: `from agents...`, `from parsers...`
+_worker_src = _root / "services" / "worker" / "src"
+if str(_worker_src) not in sys.path:
+    sys.path.insert(0, str(_worker_src))


### PR DESCRIPTION
## Problem
Unit tests were failing to collect with:
```
ModuleNotFoundError: No module named 'agents'
ModuleNotFoundError: No module named 'parsers'
ModuleNotFoundError: No module named 'civicproof_eval'
```

Tests use bare imports (`from agents...`, `from parsers...`, `from civicproof_eval...`) that require `services/worker/src` and `packages/eval/src` on the Python path. The CI test job was missing both.

## Fix
- Install `packages/common` and `packages/eval` in editable mode so `civicproof_eval` is importable
- Add `PYTHONPATH` covering all src directories to the unit test step in CI
- Add root `conftest.py` that inserts `services/worker/src` into `sys.path` for local test runs
- Apply same editable-install fix to the `eval-gate` job

## Test plan
- [ ] `pytest tests/unit/ -v` collects all tests without ImportError
- [ ] CI Tests job passes