### PR TITLE
fix(tests): replace hardcoded absolute path in test_s7_s8.py

### DIFF
--- a/tests/unit/test_s7_s8.py
+++ b/tests/unit/test_s7_s8.py
@@ -8,6 +8,8 @@ All tests are deterministic — no network calls, no LLM.
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from datetime import UTC, datetime
 
 import pytest
@@ -281,10 +283,8 @@ class TestTerraformCompliance:
 
     @pytest.fixture
     def tf_content(self):
-        with open(
-            "/Users/dev/Documents/PROJECT_LOWLEVEL/SYSTEM DESIGN PROJECTS/"
-            "CivicProof/infra/terraform/main.tf"
-        ) as f:
+        tf_path = Path(__file__).parent.parent.parent / "infra" / "terraform" / "main.tf"
+        with open(tf_path) as f:
             return f.read()
 
     def test_min_instances_zero(self, tf_content):


### PR DESCRIPTION
## Problem
`tests/unit/test_s7_s8.py:284` opened `infra/terraform/main.tf` with a hardcoded absolute path:
```python
"/Users/dev/Documents/PROJECT_LOWLEVEL/SYSTEM DESIGN PROJECTS/CivicProof/infra/terraform/main.tf"
```
This caused `FileNotFoundError` on every CI runner (and any machine that isn't the original dev box), failing 9 Terraform compliance tests.

## Fix
Replaced with a `pathlib.Path` relative to the test file:
```python
Path(__file__).parent.parent.parent / "infra" / "terraform" / "main.tf"
```

## Test plan
- [ ] `pytest tests/unit/test_s7_s8.py::TestTerraformCompliance -v` → 9 passed
- [ ] CI Tests job passes