### PR TITLE
fix(ci): use repo root as Docker build context

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
       - name: Build ${{ matrix.service }} image
         run: |
           if [ -f services/${{ matrix.service }}/Dockerfile ]; then
-            docker build services/${{ matrix.service }} -t civicproof-${{ matrix.service }}:test
+            docker build -f services/${{ matrix.service }}/Dockerfile . -t civicproof-${{ matrix.service }}:test
           else
             echo "Dockerfile for ${{ matrix.service }} not yet created — skipping"
           fi


### PR DESCRIPTION
## Summary
- Dockerfiles use repo-root relative COPY paths (`packages/common/...`, `services/*/src`)
- CI was running `docker build services/$service` which sets build context to the service dir
- Fixed by using `-f services/$service/Dockerfile .` to keep repo root as context

## Test plan
- [ ] All 3 Docker builds (api, worker, gateway) pass in CI
- [ ] All other CI jobs (lint, tests, eval gate) still pass